### PR TITLE
Fix fetch arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,3 @@ rvm:
   - 2.4.4
   - 2.5.1
   - jruby-9.1.17.0
-before_install:
-  - gem install bundler
-  - gem update bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ rvm:
   - 2.5.1
   - jruby-9.1.17.0
 before_install:
-  - gem install bundler -v '~> 1.16'
+  - gem install bundler
+  - gem update bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,4 @@ rvm:
   - 2.5.1
   - jruby-9.1.17.0
 before_install:
-  - gem install bundler
-  - gem update bundler
+  - gem install bundler -v '~> 1.16'

--- a/jserializer.gemspec
+++ b/jserializer.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 end

--- a/lib/jserializer/base.rb
+++ b/lib/jserializer/base.rb
@@ -72,7 +72,7 @@ module Jserializer
         class_eval <<-METHOD, __FILE__, __LINE__ + 1
           def #{name}
             if ::Hash === @object
-              @object.fetch(#{access_name})
+              @object.fetch(:'#{access_name}')
             else
               @object.#{access_name}
             end

--- a/test/attribute_test.rb
+++ b/test/attribute_test.rb
@@ -137,5 +137,12 @@ class AttributeTest < Minitest::Test
         result
       )
     end
+
+    it 'serialize Hash object' do
+      person = { name: 'Sam', age: 20, gender: 'M' }
+      serializer = PersonSerializer.new(person)
+      result = serializer.serializable_hash
+      assert_equal(person, result)
+    end
   end
 end


### PR DESCRIPTION
```ruby
class FooSerializer < Jserializer::Base
  attribute :foo # < Will define below method by `class_eval`.
  def foo
    if  @object === ::Hash
      @object.fetch(foo)
    else
      @object.foo
    end
  end
end

FooSerializer.new(foo: "FOO").serialized_hash
# => Will raise error `SystemStackError: stack level too deep`
```

I think above behavior is bug.
